### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ _deps = [
     "scipy",
     "tensorboard",
     "torch==2.1.0",
-    "transformers==4.35.0",
+    "transformers==4.37.0",
     "trl==0.7.4",
     "jinja2>=3.0.0",
     "tqdm>=4.64.1",


### PR DESCRIPTION
to solve the conflict:

ERROR: Cannot install spin and spin==0.1.0.dev0 because these package versions have conflicting dependencies.

The conflict is caused by:
    spin 0.1.0.dev0 depends on transformers==4.35.0
    peft 0.6.1 depends on transformers
    trl 0.7.4 depends on transformers>=4.18.0
    vllm 0.3.0 depends on transformers>=4.37.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts